### PR TITLE
FEATURE: Add option to disable source map path validation

### DIFF
--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -182,6 +182,32 @@ module SassC
       refute_match(/sourceMappingURL/, output)
     end
 
+    def test_source_map_without_path_validation
+      temp_dir('admin')
+
+      temp_file('admin/text-color.scss', <<~SCSS)
+        p {
+          color: red;
+        }
+      SCSS
+      temp_file('style.scss', <<~SCSS)
+        @import 'admin/text-color';
+
+        p {
+          padding: 20px;
+        }
+      SCSS
+      engine = Engine.new(File.read('style.scss'), {
+                            source_map_file: 'style.scss.map?foo=bar',
+                            source_map_contents: true,
+                            validate_source_map_path: false
+                          })
+      output = engine.render
+
+      assert_match(/"version":3/, engine.source_map)
+      assert_match(/style.scss.map\?foo\=bar/, output)
+    end
+
     def test_load_paths
       temp_dir('included_1')
       temp_dir('included_2')


### PR DESCRIPTION
For some reason, the repository has an extra check for URL paths for source maps. In our use case (in Discourse), we need the source map URLs to have a URL parameter like `?__ws=hostname` because we run multiple databases on the same server and the parameter helps Rails route the request to the correct database. 

This PR adds this option via the `validate_source_map_path` parameter. Example usage: 

```ruby
Engine.new(File.read('style.scss'), {
  source_map_file: 'style.scss.map?foo=bar',
  source_map_contents: true,
  validate_source_map_path: false
})
```

The code here was initially written by @xfalcox in https://github.com/tablecheck/dartsass-ruby/commit/e8a84b3d780fbf051af30f3ac215e8878e51ce63. (Full disclosure, Falco and myself both work at Discourse.) 